### PR TITLE
fix: handle VB mapping change for wildflowers & leaf_litter

### DIFF
--- a/backport_to_1_21_4/assets/minecraft/items/pink_petals.json
+++ b/backport_to_1_21_4/assets/minecraft/items/pink_petals.json
@@ -1,0 +1,27 @@
+{
+  "model": {
+    "type": "minecraft:select",
+    "property": "minecraft:custom_model_data",
+    "index": 0,
+    "cases": [
+      {
+        "when": "minecraft:wildflowers",
+        "model": {
+          "type": "minecraft:model",
+          "model": "minecraft:item/wildflowers"
+        }
+      },
+      {
+        "when": "minecraft:leaf_litter",
+        "model": {
+          "type": "minecraft:model",
+          "model": "minecraft:item/leaf_litter"
+        }
+      }
+    ],
+    "fallback": {
+      "type": "minecraft:model",
+      "model": "minecraft:item/pink_petals"
+    }
+  }
+}


### PR DESCRIPTION
VB changed mapping of wildflowers & leaf_litter from glow_lichen to pink_petals to better support the 4-item placement thing