### PR TITLE
Fix waxed copper item model references

### DIFF
--- a/backport_to_1_21_6/assets/minecraft/items/waxed_cut_copper.json
+++ b/backport_to_1_21_6/assets/minecraft/items/waxed_cut_copper.json
@@ -14,7 +14,7 @@
     ],
     "fallback": {
       "type": "minecraft:model",
-      "model": "minecraft:block/waxed_cut_copper"
+      "model": "minecraft:block/cut_copper"
     }
   }
 }

--- a/backport_to_1_21_6/assets/minecraft/items/waxed_exposed_cut_copper.json
+++ b/backport_to_1_21_6/assets/minecraft/items/waxed_exposed_cut_copper.json
@@ -14,7 +14,7 @@
     ],
     "fallback": {
       "type": "minecraft:model",
-      "model": "minecraft:block/waxed_exposed_cut_copper"
+      "model": "minecraft:block/exposed_cut_copper"
     }
   }
 }

--- a/backport_to_1_21_6/assets/minecraft/items/waxed_oxidized_cut_copper.json
+++ b/backport_to_1_21_6/assets/minecraft/items/waxed_oxidized_cut_copper.json
@@ -14,7 +14,7 @@
     ],
     "fallback": {
       "type": "minecraft:model",
-      "model": "minecraft:block/waxed_oxidized_cut_copper"
+      "model": "minecraft:block/oxidized_cut_copper"
     }
   }
 }

--- a/backport_to_1_21_6/assets/minecraft/items/waxed_weathered_cut_copper.json
+++ b/backport_to_1_21_6/assets/minecraft/items/waxed_weathered_cut_copper.json
@@ -14,7 +14,7 @@
     ],
     "fallback": {
       "type": "minecraft:model",
-      "model": "minecraft:block/waxed_weathered_cut_copper"
+      "model": "minecraft:block/weathered_cut_copper"
     }
   }
 }


### PR DESCRIPTION
Update fallback model references in waxed cut copper item JSON files to point to the correct unwaxed block models. The item models should fall back to the base block variants without the waxed prefix.